### PR TITLE
Add rust button example

### DIFF
--- a/rs/README.md
+++ b/rs/README.md
@@ -3,28 +3,27 @@
 Three small examples which you can use to test GPIO
 on a Raspberry Pi.  
 
-PLEASE NOTE that the pin numbers are hardcoded to:
-
-```
-Blue    17
-Yellow  5
-Red     26
-```
+PLEASE NOTE that the pin numbers are hardcoded in
+[lights.rs](src/lights.rs) and [button.rs](src/button.rs).
 
 ## Usage
 
-Blink pin 17
+Blink pin 17:
 
 `cargo run blink`
 
-Blink three pins at the same time
+Blink three pins at the same time:
 
 `cargo run blink3`
 
-Count from 0..8 in binary
+Count from 0..8 in binary:
 
 `cargo run flashy`
 
-Blink wildly after a given number of seconds
+Blink wildly after a given number of seconds:
 
 `cargo run timer 10`
+
+Turn off pin 18 when you push a button on pin 25:
+
+`cargo run button`

--- a/rs/README.md
+++ b/rs/README.md
@@ -34,7 +34,12 @@ Please note that the GPIO pin numbers are hardcoded in
 
 ### Sleepy Thread Heuristic After First Export
 
-We found that we needed to give "the system" about 50 millis
-to catch up to the GPIO pins changing from an _unexported_
-to an _exported_ state.  To that end, we've defined the
-`on_export::wait()` function in [on_export.rs](src/on_export.rs).
+We found that we needed to
+give "the system" about 50 millis to catch up to the GPIO pins
+changing from an _unexported_ to an _exported_ state.  To that
+end, we've defined the `on_export::wait()` function.  We needed
+to call this prior to setting directions on individual pins.
+
+The python GPIO lib doesn't seem to have this problem, but
+we surmise that it's doing some additional work to make
+setting pin directions painless.

--- a/rs/README.md
+++ b/rs/README.md
@@ -3,7 +3,11 @@
 Three small examples which you can use to test GPIO
 on a Raspberry Pi.  
 
-PLEASE NOTE that the pin numbers are hardcoded in
+This work makes use of the [rust-sysfs-gpio](https://github.com/rust-embedded/rust-sysfs-gpio) library.
+
+## Caveat Emptor: Hardcoded Pin Numbers
+
+Please note that the GPIO pin numbers are hardcoded in
 [lights.rs](src/lights.rs) and [button.rs](src/button.rs).
 
 ## Usage

--- a/rs/README.md
+++ b/rs/README.md
@@ -5,11 +5,6 @@ on a Raspberry Pi.
 
 This work makes use of the [rust-sysfs-gpio](https://github.com/rust-embedded/rust-sysfs-gpio) library.
 
-## Caveat Emptor: Hardcoded Pin Numbers
-
-Please note that the GPIO pin numbers are hardcoded in
-[lights.rs](src/lights.rs) and [button.rs](src/button.rs).
-
 ## Usage
 
 Blink pin 17:
@@ -31,3 +26,15 @@ Blink wildly after a given number of seconds:
 Turn off pin 18 when you push a button on pin 25:
 
 `cargo run button`
+
+## Caveat Emptor: Hardcoded Pin Numbers
+
+Please note that the GPIO pin numbers are hardcoded in
+[lights.rs](src/lights.rs) and [button.rs](src/button.rs).
+
+### Sleepy Thread Heuristic After First Export
+
+We found that we needed to give "the system" about 50 millis
+to catch up to the GPIO pins changing from an _unexported_
+to an _exported_ state.  To that end, we've defined the
+`on_export::wait()` function in [on_export.rs](src/on_export.rs).

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -11,9 +11,10 @@ pub fn run() {
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {
-                    match button_pin.get_value() {
-                        Ok(1) => led_pin.set_value(1).unwrap(),
-                        _ => led_pin.set_value(0).unwrap(),
+                    if let Ok(1) = button_pin.get_value() {
+                        led_pin.set_value(1).unwrap()
+                    } else {
+                        led_pin.set_value(0).unwrap()
                     }
                 }
             })

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use sysfs_gpio::{Direction, Pin};
 
 pub fn run() {
-    const SLEEP_HEURISTIC_MILLIS: u64 = 1;
+    const SLEEP_HEURISTIC_MILLIS: u64 = 10;
 
     let led_pin = Pin::new(18);
     let button_pin = Pin::new(25);

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -11,10 +11,9 @@ pub fn run() {
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {
-                    if let Ok(1) = button_pin.get_value() {
-                        led_pin.set_value(0).unwrap();
-                    } else {
-                        led_pin.set_value(1).unwrap();
+                    match button_pin.get_value() {
+                        Ok(1) => led_pin.set_value(0).unwrap(),
+                        _ => led_pin.set_value(1).unwrap(),
                     }
                 }
             })

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -1,5 +1,7 @@
 extern crate sysfs_gpio;
 
+use std::thread::sleep;
+use std::time::Duration;
 use sysfs_gpio::{Direction, Pin};
 
 pub fn run() {
@@ -8,6 +10,7 @@ pub fn run() {
     led_pin
         .with_exported(|| {
             button_pin.with_exported(|| {
+                sleep(Duration::from_millis(200));
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -12,8 +12,8 @@ pub fn run() {
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {
                     match button_pin.get_value() {
-                        Ok(1) => led_pin.set_value(0).unwrap(),
-                        _ => led_pin.set_value(1).unwrap(),
+                        Ok(1) => led_pin.set_value(1).unwrap(),
+                        _ => led_pin.set_value(0).unwrap(),
                     }
                 }
             })

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -11,10 +11,9 @@ pub fn run() {
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {
-                    if let Ok(1) = button_pin.get_value() {
-                        led_pin.set_value(1).unwrap()
-                    } else {
-                        led_pin.set_value(0).unwrap()
+                    match button_pin.get_value() {
+                        Ok(1) => led_pin.set_value(1).unwrap(),
+                        _ => led_pin.set_value(0).unwrap(),
                     }
                 }
             })

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -1,25 +1,23 @@
 extern crate sysfs_gpio;
 
-
-const BUTTON_PIN: u32 = 25;
+use sysfs_gpio::{Direction, Pin};
 
 pub fn run() {
     let led_pin = Pin::new(18);
     let button_pin = Pin::new(25);
     led_pin
         .with_exported(|| {
-            button_pin.with_exported ( ||
-            {
-led_pin.set_direction(Direction::Out).unwrap();
-            loop {
-                led_pin.set_value(0).unwrap();
-                sleep(Duration::from_millis(200));
-                led_pin.set_value(1).unwrap();
-                sleep(Duration::from_millis(200));
-            }
-            }
-            )
-            
+            button_pin.with_exported(|| {
+                led_pin.set_direction(Direction::Out).unwrap();
+                button_pin.set_direction(Direction::In).unwrap();
+                loop {
+                    if let Ok(1) = button_pin.get_value() {
+                        led_pin.set_value(0).unwrap();
+                    } else {
+                        led_pin.set_value(1).unwrap();
+                    }
+                }
+            })
         })
         .unwrap();
 }

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -1,18 +1,13 @@
 extern crate sysfs_gpio;
 
-use std::thread::sleep;
-use std::time::Duration;
 use sysfs_gpio::{Direction, Pin};
 
 pub fn run() {
-    const SLEEP_HEURISTIC_MILLIS: u64 = 10;
-
     let led_pin = Pin::new(18);
     let button_pin = Pin::new(25);
     led_pin
         .with_exported(|| {
             button_pin.with_exported(|| {
-                sleep(Duration::from_millis(SLEEP_HEURISTIC_MILLIS));
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -1,0 +1,25 @@
+extern crate sysfs_gpio;
+
+
+const BUTTON_PIN: u32 = 25;
+
+pub fn run() {
+    let led_pin = Pin::new(18);
+    let button_pin = Pin::new(25);
+    led_pin
+        .with_exported(|| {
+            button_pin.with_exported ( ||
+            {
+led_pin.set_direction(Direction::Out).unwrap();
+            loop {
+                led_pin.set_value(0).unwrap();
+                sleep(Duration::from_millis(200));
+                led_pin.set_value(1).unwrap();
+                sleep(Duration::from_millis(200));
+            }
+            }
+            )
+            
+        })
+        .unwrap();
+}

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use sysfs_gpio::{Direction, Pin};
 
 pub fn run() {
+    const SLEEP_HEURISTIC_MILLIS: u64 = 1;
+
     let led_pin = Pin::new(18);
     let button_pin = Pin::new(25);
     led_pin
         .with_exported(|| {
             button_pin.with_exported(|| {
-                sleep(Duration::from_millis(200));
+                sleep(Duration::from_millis(SLEEP_HEURISTIC_MILLIS));
                 led_pin.set_direction(Direction::Out).unwrap();
                 button_pin.set_direction(Direction::In).unwrap();
                 loop {

--- a/rs/src/lights.rs
+++ b/rs/src/lights.rs
@@ -1,5 +1,6 @@
 extern crate sysfs_gpio;
 
+use on_export;
 use std::thread::sleep;
 use std::time::Duration;
 use sysfs_gpio::{Direction, Pin};
@@ -12,6 +13,9 @@ pub fn blink() {
     let blue_pin = Pin::new(BLUE_PIN);
     blue_pin
         .with_exported(|| {
+            // give the system a little time
+            // to catch up to export
+            on_export::wait();
             blue_pin.set_direction(Direction::Out).unwrap();
             loop {
                 blue_pin.set_value(0).unwrap();
@@ -33,6 +37,7 @@ pub fn blink3() {
         .with_exported(|| {
             yellow_pin.with_exported(|| {
                 red_pin.with_exported(|| {
+                    on_export::wait();
                     blue_pin.set_direction(Direction::Out).unwrap();
                     yellow_pin.set_direction(Direction::Out).unwrap();
                     red_pin.set_direction(Direction::Out).unwrap();
@@ -69,6 +74,7 @@ pub fn flashy() {
         .with_exported(|| {
             yellow_pin.with_exported(|| {
                 red_pin.with_exported(|| {
+                    on_export::wait();
                     blue_pin.set_direction(Direction::Out).unwrap();
                     yellow_pin.set_direction(Direction::Out).unwrap();
                     red_pin.set_direction(Direction::Out).unwrap();

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -1,5 +1,6 @@
 extern crate sysfs_gpio;
 
+pub mod button;
 pub mod lights;
 
 use std::env;
@@ -10,6 +11,7 @@ const TIMER_DEFAULT_SECS: u64 = 5;
 
 fn main() {
     match env::args().nth(1).as_ref().map(|s| s.as_str()) {
+        Some("button") => button::run(),
         Some("blink3") => lights::blink3(),
         Some("flashy") => lights::flashy(),
         Some("timer") => {
@@ -22,6 +24,7 @@ fn main() {
             );
             lights::timer(secs, &lights::flashy)
         }
+
         _ => lights::blink(),
     }
 }

--- a/rs/src/mod.rs
+++ b/rs/src/mod.rs
@@ -1,4 +1,0 @@
-/*pub mod button;
-pub mod lights;
-pub mod on_export;
-*/

--- a/rs/src/mod.rs
+++ b/rs/src/mod.rs
@@ -1,1 +1,2 @@
+pub mod button;
 pub mod lights;

--- a/rs/src/on_export.rs
+++ b/rs/src/on_export.rs
@@ -1,0 +1,6 @@
+use std::thread::sleep;
+use std::time::Duration;
+
+const SLEEP_HEURISTIC_MILLIS: u64 = 50;
+
+pub fn wait() { sleep(Duration::from_millis(SLEEP_HEURISTIC_MILLIS)) }

--- a/rs/src/on_export.rs
+++ b/rs/src/on_export.rs
@@ -3,6 +3,11 @@ use std::time::Duration;
 
 const SLEEP_HEURISTIC_MILLIS: u64 = 50;
 
+/// wait ~50ms after exporting this pin.
+/// if you set_direction *immediately* after
+/// entering this closure, without your
+/// pin having been exported on a *previous*
+/// run, you'll crash.
 pub fn wait() {
     sleep(Duration::from_millis(SLEEP_HEURISTIC_MILLIS))
 }


### PR DESCRIPTION
...and define `on_export::wait()`, make use of it in the other examples, and update the README.