### PR TITLE
MIDI note order

### DIFF
--- a/midi_light_show/Cargo.lock
+++ b/midi_light_show/Cargo.lock
@@ -304,7 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "midi_light_show"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/midi_light_show/Cargo.toml
+++ b/midi_light_show/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midi_light_show"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Terkwood <<>>"]
 
 [dependencies]

--- a/midi_light_show/Settings.toml
+++ b/midi_light_show/Settings.toml
@@ -3,5 +3,5 @@ pwm = true  # disable if you don't want lights to dim based on note velocity
 layout = "extended"
 
 [pins]
-extended = [13, 6, 5, 7, 23, 18, 15, 14, 21, 26, 20, 16, 19, 11, 9, 10, 22, 27, 8, 25, 17, 4, 3, 2]
-basic = [13, 6, 5, 7, 23, 18, 15, 14]
+extended = [2, 3, 4, 17, 25, 8, 27, 22, 10, 9, 11, 19, 16, 20, 26, 21, 14, 15, 18, 23, 7, 5, 6, 13]
+basic = [14, 15, 18, 23, 7, 5, 6, 13]


### PR DESCRIPTION
Thanks to some helpful commentary on our YouTube channel, we realize that the order of the LEDs was reversed.  Generally, based on the layout of the piano, one would expect lower pitched notes to be on the left side, and higher pitched notes to be on the right side.  This changeset reflects that idea.